### PR TITLE
Add aarch64 support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ SMALL = 0
 DEBUG = 0
 
 ARCHS32 := i386 arm
-ARCHS64 := amd64
+ARCHS64 := amd64 aarch64
 ARCHS := $(ARCHS32) $(ARCHS64)
 
 CFLAGS_i386 = -m32

--- a/src/aarch64/z_trampo.S
+++ b/src/aarch64/z_trampo.S
@@ -1,0 +1,9 @@
+       .text
+       .align  4
+       .globl  z_trampo
+       .type   z_trampo,%function
+z_trampo:
+       mov     sp, x1
+       mov     x1, x0
+       mov     x0, x2
+       br      x1


### PR DESCRIPTION
Based on arm `z_trampo.S`. Assembly needed some editing:
- Register names: r0 -> x0
- Branch instruction: bx -> br